### PR TITLE
Added Register Link in Navigation,  closes  #29

### DIFF
--- a/lib/omedis_web/components/general_components.ex
+++ b/lib/omedis_web/components/general_components.ex
@@ -707,7 +707,7 @@ defmodule OmedisWeb.GeneralComponents do
         <.link navigate="/login">
           Login
         </.link>
-        <.link navigate="/login">
+        <.link navigate="/register">
           Register
         </.link>
       </div>


### PR DESCRIPTION
We now have
```
<div :if={@current_user == nil} class="flex p-2 flex-col gap-2">
        <.link navigate="/login">
          Login
        </.link>
        <.link navigate="/register">
          Register
        </.link>
      </div>
```