### PR TITLE
Setup Time Tracking Route and Component with dummy data 

### DIFF
--- a/lib/omedis_web.ex
+++ b/lib/omedis_web.ex
@@ -90,6 +90,7 @@ defmodule OmedisWeb do
       use Gettext, backend: OmedisWeb.Gettext
 
       import OmedisWeb.GeneralComponents
+      import OmedisWeb.TimeTracking
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/omedis_web/components/time_tracking.ex
+++ b/lib/omedis_web/components/time_tracking.ex
@@ -1,0 +1,303 @@
+defmodule OmedisWeb.TimeTracking do
+  @moduledoc """
+  Provides components for time tracking and visualization.
+
+  This module includes functions for rendering a time tracking dashboard,
+  individual time entries, and utility functions for time calculations.
+  """
+  use Phoenix.Component
+
+  attr :categories, :list, required: true
+  attr :starts_at, :any, required: true
+  attr :ends_at, :any, required: true
+  attr :current_time, :any, required: true
+
+  @doc """
+  Renders the main dashboard component.
+
+  ## Example
+
+      <.dashboard_component
+        categories={[%{name: "Work", color_code: "#FF0000", entries: [...]}, ...]}
+        starts_at={~T[08:00:00]}
+        ends_at={~T[18:00:00]}
+        current_time={~T[13:30:00]}
+      />
+  """
+  def dashboard_component(assigns) do
+    ~H"""
+    <div class="w-[100%]">
+      <.dashboard_card
+        categories={@categories}
+        starts_at={@starts_at}
+        ends_at={@ends_at}
+        current_time={@current_time}
+      />
+    </div>
+    """
+  end
+
+  @doc """
+  Dashboard card component. This holds the whole dashboard.
+  """
+
+  attr :categories, :list, required: true
+  attr :starts_at, :any, required: true
+  attr :ends_at, :any, required: true
+  attr :current_time, :any, required: true
+
+  def dashboard_card(assigns) do
+    ~H"""
+    <div class="md:w-[50%] w-[90%] h-[70vh]  m-auto flex justify-start gap-1 items-end">
+      <div class="md:w-[40%]  flex justify-start flex-col gap-5 h-[100%]">
+        <%= for category <- @categories do %>
+          <.category_button category={category} />
+        <% end %>
+      </div>
+
+      <div class="w-[30%] flex items-end justify-end gap-4 h-[100%] ">
+        <div class="w-[40%] relative h-[100%]">
+          <%= for entry <- format_entries(@categories) do %>
+            <div
+              class="absolute w-[100%]"
+              style={
+                "top: #{get_top_to_use_for_entry(entry, @starts_at, @ends_at)}%;
+                background-color: #{entry.color_code};
+                height: #{get_height_to_use_for_entry(entry, @starts_at, @ends_at)}%;
+                "
+              }
+            />
+          <% end %>
+        </div>
+      </div>
+
+      <div class="relative h-[100%]">
+        <div class="w-[100%] h-[100%]  flex flex-row gap-1">
+          <div class=" h-[100%] ">
+            <p class="w-[5px] bg-black h-[100%]"></p>
+          </div>
+
+          <div class="w-[100%] h-[100%] flex flex-row gap-1">
+            <.time_intervals starts_at={@starts_at} ends_at={@ends_at} />
+          </div>
+        </div>
+
+        <div
+          class="md:w-[50px] w-[40px] h-[3px] bg-red-500 absolute "
+          style={"top: #{get_top_to_use_for_current_time(@starts_at, @ends_at, @current_time)}%; position: absolute "}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Time intervals component. This holds the time intervals from the minimum time to the maximum time , in intervals of hours , the interval
+  is calculated based on the total hours between the minimum and maximum time.
+  We have a total of maximum 12 intervals.
+  """
+
+  attr :starts_at, :any, required: true
+  attr :ends_at, :any, required: true
+
+  def time_intervals(assigns) do
+    ~H"""
+    <div class="w-[100%] h-[100%] flex flex-col justify-between  gap-1">
+      <%= for time_interval <- get_time_intervals_array(@starts_at, @ends_at) do %>
+        <p>
+          <%= format_time(time_interval) %>
+        </p>
+      <% end %>
+    </div>
+    """
+  end
+
+  @doc """
+  Get the time intervals array based on the start and end time.
+
+  ## Example
+
+      iex> get_time_intervals_array(~T[08:00:00], ~T[18:00:00])
+      [~T[08:00:00], ~T[09:00:00], ~T[10:00:00], ~T[11:00:00], ~T[12:00:00],
+       ~T[13:00:00], ~T[14:00:00], ~T[15:00:00], ~T[16:00:00], ~T[17:00:00],
+       ~T[18:00:00]]
+  """
+  def get_time_intervals_array(starts_at, ends_at) do
+    total_hours = Time.diff(ends_at, starts_at, :hour)
+    max_intervals = 12
+
+    interval_step =
+      if total_hours + 1 > max_intervals do
+        div(total_hours + 1, max_intervals)
+      else
+        1
+      end
+
+    Enum.to_list(0..total_hours)
+    |> Enum.filter(fn hour -> rem(hour, interval_step) == 0 end)
+    |> Enum.map(fn hour -> Time.add(starts_at, hour * 3600, :second) end)
+  end
+
+  @doc """
+  Get the height to use for the entry based on the total time spent on the entry and the maximum time in minutes.
+
+  ## Example
+
+      iex> entry = %{starts_at: ~T[09:00:00], ends_at: ~T[11:00:00]}
+      iex> get_height_to_use_for_entry(entry, ~T[08:00:00], ~T[18:00:00])
+      16.666666666666668 # Represents 16.67% of the total height
+  """
+  def get_height_to_use_for_entry(entry, starts_at, ends_at) do
+    time_spent = Time.diff(entry.ends_at, entry.starts_at, :minute)
+    maximum_time_in_minutes = Time.diff(ends_at, starts_at, :minute)
+    time_spent / maximum_time_in_minutes * 100
+  end
+
+  @doc """
+  Get the absolute top % to use for the entry based on the total time spent on the entry and the maximum time in minutes.
+
+  ## Example
+
+      iex> entry = %{starts_at: ~T[10:00:00], ends_at: ~T[12:00:00]}
+      iex> get_top_to_use_for_entry(entry, ~T[08:00:00], ~T[18:00:00])
+      20.0 # Represents 20% from the top
+  """
+  def get_top_to_use_for_entry(entry, starts_at, ends_at) do
+    time_difference_between_starts_at_and_entry = Time.diff(entry.starts_at, starts_at, :minute)
+
+    time_difference_between_starts_at_and_entry / Time.diff(ends_at, starts_at, :minute) * 100
+  end
+
+  @doc """
+  Get the absolute top % to use for the current time based on the total time spent on the entry and the maximum time in minutes.
+
+  ## Example
+
+      iex> get_top_to_use_for_current_time(~T[08:00:00], ~T[18:00:00], ~T[13:00:00])
+      50.0 # Represents 50% from the top
+  """
+  def get_top_to_use_for_current_time(starts_at, ends_at, current_time) do
+    time_spent = Time.diff(current_time, starts_at, :minute)
+    maximum_time_in_minutes = Time.diff(ends_at, starts_at, :minute)
+    time_spent / maximum_time_in_minutes * 100
+  end
+
+  @doc """
+  The category button component. This holds the category button.
+  """
+
+  attr :category, :any, required: true
+
+  def category_button(assigns) do
+    ~H"""
+    <button
+      class="w-[100%] h-[100%] h-[40px] rounded-md"
+      style={"background-color: #{@category.color_code};"}
+    >
+      <span class="text-white text-sm p-2  md:text-base">
+        <%= @category.name %>
+      </span>
+    </button>
+    """
+  end
+
+  @doc """
+  This formats the time into 24-hour format for user readability.
+
+  ## Example
+
+      iex> format_time(~T[14:30:00])
+      "14:30"
+  """
+  def format_time(%Time{hour: hour, minute: minute}) do
+    "#{String.pad_leading(Integer.to_string(hour), 2, "0")}:#{String.pad_leading(Integer.to_string(minute), 2, "0")}"
+  end
+
+  @doc """
+  This formats the entries to be used in the dashboard card.
+  The entries are listed in order of their start time.
+  They are also assigned a color code based on their category.
+
+  ## Example
+
+      iex> categories = [
+      ...>   %{name: "Work", color_code: "#FF0000", entries: [%{starts_at: ~T[09:00:00], ends_at: ~T[12:00:00]}]},
+      ...>   %{name: "Break", color_code: "#00FF00", entries: [%{starts_at: ~T[12:00:00], ends_at: ~T[13:00:00]}]}
+      ...> ]
+      iex> format_entries(categories)
+      [
+        %{starts_at: ~T[09:00:00], ends_at: ~T[12:00:00], color_code: "#FF0000"},
+        %{starts_at: ~T[12:00:00], ends_at: ~T[13:00:00], color_code: "#00FF00"}
+      ]
+  """
+  def format_entries(categories) do
+    categories
+    |> Enum.map(fn category ->
+      category.entries
+    end)
+    |> List.flatten()
+    |> Enum.sort_by(fn %{starts_at: starts_at, ends_at: ends_at} -> {starts_at, ends_at} end)
+    |> Enum.map(fn x ->
+      %{
+        starts_at: x.starts_at,
+        ends_at: x.ends_at,
+        color_code:
+          Enum.find(categories, fn category ->
+            category.entries |> Enum.find(fn entry -> entry.starts_at == x.starts_at end)
+          end).color_code
+      }
+    end)
+  end
+
+  attr :starts_at, :any, required: true
+  attr :ends_at, :any, required: true
+  attr :events, :list, required: true
+
+  def time_tracking(assigns) do
+    ~H"""
+    <div class="w-[100%] h-[100%] flex flex-row">
+      <div class="w-[10%] h-[100%]">
+        <.time_intervals starts_at={@starts_at} ends_at={@ends_at} />
+      </div>
+      <div class="w-[90%] h-[100%] relative">
+        <%= for event <- @events do %>
+          <div
+            class="absolute w-[100%] bg-gray-200 rounded-md p-2"
+            style={"top: #{calculate_top_position(event.starts_at, @starts_at, @ends_at)}%; height: #{calculate_height(event.starts_at, event.ends_at, @starts_at, @ends_at)}%;"}
+          >
+            <%= event.title %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Calculates the top position for an event as a percentage of the timeline.
+
+  ## Example
+
+      iex> calculate_top_position(~T[10:00:00], ~T[08:00:00], ~T[18:00:00])
+      20.0 # Represents 20% from the top
+  """
+  def calculate_top_position(event_start, timeline_start, timeline_end) do
+    total_minutes = Time.diff(timeline_end, timeline_start, :minute)
+    event_minutes = Time.diff(event_start, timeline_start, :minute)
+    event_minutes / total_minutes * 100
+  end
+
+  @doc """
+  Calculates the height of an event as a percentage of the timeline.
+
+  ## Example
+
+      iex> calculate_height(~T[10:00:00], ~T[12:00:00], ~T[08:00:00], ~T[18:00:00])
+      20.0 # Represents 20% of the total height
+  """
+  def calculate_height(event_start, event_end, timeline_start, timeline_end) do
+    total_minutes = Time.diff(timeline_end, timeline_start, :minute)
+    event_duration = Time.diff(event_end, event_start, :minute)
+    event_duration / total_minutes * 100
+  end
+end

--- a/lib/omedis_web/live/tenant_live/show.ex
+++ b/lib/omedis_web/live/tenant_live/show.ex
@@ -15,6 +15,9 @@ defmodule OmedisWeb.TenantLive.Show do
         <.link patch={~p"/tenants/#{@tenant.slug}/log_categories"} phx-click={JS.push_focus()}>
           <.button>Log categories</.button>
         </.link>
+        <.link navigate={~p"/tenants/#{@tenant.slug}/today"} phx-click={JS.push_focus()}>
+          <.button>Today</.button>
+        </.link>
       </:actions>
     </.header>
 

--- a/lib/omedis_web/live/tenant_live/today.ex
+++ b/lib/omedis_web/live/tenant_live/today.ex
@@ -1,0 +1,83 @@
+defmodule OmedisWeb.TenantLive.Today do
+  use OmedisWeb, :live_view
+  alias Omedis.Accounts.Tenant
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.dashboard_component
+        categories={@categories}
+        starts_at={~T[08:00:00]}
+        ends_at={~T[17:00:00]}
+        current_time={@current_time}
+      />
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:categories, categories())
+     |> assign(:current_time, ~T[10:00:00])}
+  end
+
+  @impl true
+  def handle_params(%{"slug" => slug}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, "Today")
+     |> assign(:tenant, Tenant.by_slug!(slug))}
+  end
+
+  defp categories do
+    [
+      %{
+        color_code: "#3F88C5",
+        name: "Category 1",
+        entries: [
+          %{
+            starts_at: ~T[08:00:00],
+            ends_at: ~T[08:10:00]
+          },
+          %{
+            starts_at: ~T[09:01:00],
+            ends_at: ~T[09:55:00]
+          }
+        ]
+      },
+      %{
+        color_code: "#D58936",
+        name: "Category 2",
+        entries: [
+          %{
+            starts_at: ~T[08:11:00],
+            ends_at: ~T[09:00:00]
+          }
+        ]
+      },
+      %{
+        color_code: "#881D36",
+        name: "Category 3",
+        entries: [
+          %{
+            starts_at: ~T[09:56:00],
+            ends_at: ~T[11:15:00]
+          }
+        ]
+      },
+      %{
+        color_code: "#82AA60",
+        name: "Category 4",
+        entries: []
+      },
+      %{
+        color_code: "#FF9960",
+        name: "Category 5",
+        entries: []
+      }
+    ]
+  end
+end

--- a/lib/omedis_web/router.ex
+++ b/lib/omedis_web/router.ex
@@ -39,6 +39,7 @@ defmodule OmedisWeb.Router do
 
       live "/tenants/:slug/log_categories", LogCategoryLive.Index, :index
       live "/tenants/:slug/log_categories/new", LogCategoryLive.Index, :new
+      live "/tenants/:slug/today", TenantLive.Today, :index
       live "/tenants/:slug/log_categories/:id", LogCategoryLive.Show, :show
       live "/tenants/:slug/log_categories/:id/edit", LogCategoryLive.Index, :edit
       live "/tenants/:slug/log_categories/:id/show/edit", LogCategoryLive.Show, :edit


### PR DESCRIPTION
In "/tenants/:slug/today" we now have , with the dashboard component having dummy data

![Screenshot 2024-09-20 at 14 21 20](https://github.com/user-attachments/assets/4bbe66b1-ad2b-4f62-86bd-f50bdc4338de)
