### PR TITLE
Added Calculation for user resource for name

### DIFF
--- a/lib/omedis/accounts/user.ex
+++ b/lib/omedis/accounts/user.ex
@@ -32,7 +32,7 @@ defmodule Omedis.Accounts.User do
   end
 
   calculations do
-    calculate :name, :string, expr(first_name <> " " <> last_name)
+    calculate :as_string, :string, expr(first_name <> " " <> last_name)
   end
 
   actions do
@@ -98,7 +98,7 @@ defmodule Omedis.Accounts.User do
   preparations do
     prepare build(
               load: [
-                :name
+                :as_string
               ]
             )
   end

--- a/lib/omedis_web/components/general_components.ex
+++ b/lib/omedis_web/components/general_components.ex
@@ -379,7 +379,7 @@ defmodule OmedisWeb.GeneralComponents do
                   <span class="hidden lg:flex lg:items-center">
                     <span class="ml-4 text-sm font-medium leading-6 text-gray-900" aria-hidden="true">
                       <%= if @current_user do %>
-                        <%= @current_user.name %>
+                        <%= @current_user.as_string %>
                       <% else %>
                         <.link navigate="/login" class="text-blue-500">Login</.link>
                         <span>


### PR DESCRIPTION
We now have

```
#Omedis.Accounts.User<
    as_string: "Michael Changed Munavu",
    __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
    id: "3eb02bd9-096b-4f69-833a-bc8b69330da6",
    email: #Ash.CiString<"michaelmunavu83@gmail.com">,
    first_name: "Michael Changed",
    last_name: "Munavu",
    gender: "Female",
    birthdate: ~D[1985-02-14],
    current_tenant_id: "a615f85d-7263-4c3c-914e-8d18a68a3288",
    created_at: ~U[2024-09-21 11:06:27.953962Z],
    updated_at: ~U[2024-09-23 11:42:51.454333Z],
    aggregates: %{},
    calculations: %{},
    ...
  >

``` 

The name is now as `first_name` and `last_name` combined in the `as_string` attribute


I have also used this value in the top navigation.


@wintermeyer  , for the tenant resource , we already have it as  `name`  only , not first name and last name
