### PR TITLE
Added Back Button and delete for groups , closes  #102

### DIFF
--- a/lib/omedis_web/live/group_live/index.ex
+++ b/lib/omedis_web/live/group_live/index.ex
@@ -6,6 +6,9 @@ defmodule OmedisWeb.GroupLive.Index do
   @impl true
   def render(assigns) do
     ~H"""
+    <div>
+      <.link navigate={~p"/tenants/#{@tenant.slug}"} class="button">Back</.link>
+    </div>
     <.header>
       <%= with_locale(@language, fn -> %>
         <%= gettext("Listing Groups") %>
@@ -38,13 +41,22 @@ defmodule OmedisWeb.GroupLive.Index do
         <%= group.slug %>
       </:col>
 
-      <:action :let={{_id, group}}>
-        <.link patch={~p"/tenants/#{@tenant.slug}/groups/#{group}/edit"}>
-          <%= with_locale(@language, fn -> %>
-            <%= gettext("Edit") %>
-          <% end) %>
-        </.link>
-      </:action>
+      <:col :let={{_id, group}} label={with_locale(@language, fn -> gettext("Actions") end)}>
+        <div class="flex gap-4">
+          <.link patch={~p"/tenants/#{@tenant.slug}/groups/#{group}/edit"} class="font-semibold">
+            <%= with_locale(@language, fn -> %>
+              <%= gettext("Edit") %>
+            <% end) %>
+          </.link>
+          <.link>
+            <p class="font-semibold" phx-click="delete" phx-value-id={group.id}>
+              <%= with_locale(@language, fn -> %>
+                <%= gettext("Delete") %>
+              <% end) %>
+            </p>
+          </.link>
+        </div>
+      </:col>
     </.table>
 
     <.modal
@@ -85,7 +97,7 @@ defmodule OmedisWeb.GroupLive.Index do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  defp apply_action(socket, :edit, %{"id" => id}) do
+  defp apply_action(socket, :edit, %{"group_id" => id}) do
     socket
     |> assign(:page_title, with_locale(socket.assigns.language, fn -> gettext("Edit Group") end))
     |> assign(:group, Ash.get!(Omedis.Accounts.Group, id))
@@ -104,6 +116,19 @@ defmodule OmedisWeb.GroupLive.Index do
       with_locale(socket.assigns.language, fn -> gettext("Listing Groups") end)
     )
     |> assign(:group, nil)
+  end
+
+  @impl true
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    group = Ash.get!(Omedis.Accounts.Group, id)
+
+    Group.destroy(group)
+
+    {:noreply,
+     socket
+     |> stream_delete(:groups, group)
+     |> put_flash(:info, with_locale(socket.assigns.language, fn -> gettext("Group deleted") end))}
   end
 
   @impl true


### PR DESCRIPTION

![Screenshot 2024-10-01 at 05 17 15](https://github.com/user-attachments/assets/edf8dd0c-6583-46f9-91de-7a2dc5b63afc)
![Screenshot 2024-10-01 at 05 17 30](https://github.com/user-attachments/assets/fa30dada-65d7-4461-bad2-c17077883455)

![Screenshot 2024-10-01 at 05 17 08](https://github.com/user-attachments/assets/8795483e-aa29-4542-a28c-0f8ffbff2fee)


@wintermeyer  , now when you click on a tenant , you see a groups tab , when you click on this , you can do CRUD on groups for a tenant 

**PS**

To now access the today page , you have to click an individual group then you will see the `Today` tab
