### PR TITLE
Fix time display bug , closes #114 , closes #115

### DIFF
--- a/lib/omedis_web/components/time_tracking.ex
+++ b/lib/omedis_web/components/time_tracking.ex
@@ -136,18 +136,7 @@ defmodule OmedisWeb.TimeTracking do
        ~T[18:00:00]]
   """
   def get_time_intervals_array(start_at, end_at) do
-    # Round down start time to nearest full hour
-    rounded_start = Time.new!(start_at.hour, 0, 0)
-
-    # Round up end time to nearest full hour
-    rounded_end =
-      if end_at.minute > 0 or end_at.second > 0 do
-        Time.add(Time.new!(end_at.hour, 0, 0), 3600, :second)
-      else
-        Time.new!(end_at.hour, 0, 0)
-      end
-
-    total_hours = Time.diff(rounded_end, rounded_start, :hour)
+    total_hours = Time.diff(end_at, start_at, :hour)
     max_intervals = 12
 
     interval_step =
@@ -159,7 +148,7 @@ defmodule OmedisWeb.TimeTracking do
 
     Enum.to_list(0..total_hours)
     |> Enum.filter(fn hour -> rem(hour, interval_step) == 0 end)
-    |> Enum.map(fn hour -> Time.add(rounded_start, hour * 3600, :second) end)
+    |> Enum.map(fn hour -> Time.add(start_at, hour * 3600, :second) end)
   end
 
   @doc """

--- a/lib/omedis_web/live/tenant_live/today.ex
+++ b/lib/omedis_web/live/tenant_live/today.ex
@@ -42,10 +42,12 @@ defmodule OmedisWeb.TenantLive.Today do
     start_at =
       get_start_time_to_use(min_start_in_entries, tenant.daily_start_at)
       |> format_timezone(tenant.timezone)
+      |> round_down_start_at()
 
     end_at =
       get_end_time_to_use(max_end_in_entries, tenant.daily_end_at)
       |> format_timezone(tenant.timezone)
+      |> round_up_end_at()
 
     update_categories_and_current_time_every_minute()
 
@@ -99,10 +101,12 @@ defmodule OmedisWeb.TenantLive.Today do
     start_at =
       get_start_time_to_use(min_start_in_entries, tenant.daily_start_at)
       |> format_timezone(tenant.timezone)
+      |> round_down_start_at()
 
     end_at =
       get_end_time_to_use(max_end_in_entries, tenant.daily_end_at)
       |> format_timezone(tenant.timezone)
+      |> round_up_end_at()
 
     current_time = Time.utc_now() |> format_timezone(tenant.timezone)
 
@@ -222,6 +226,18 @@ defmodule OmedisWeb.TenantLive.Today do
     case max_end do
       nil -> end_at
       _ -> if Time.compare(end_at, max_end) == :gt, do: end_at, else: max_end
+    end
+  end
+
+  def round_down_start_at(start_at) do
+    Time.new!(start_at.hour, 0, 0)
+  end
+
+  def round_up_end_at(end_at) do
+    if end_at.minute > 0 or end_at.second > 0 do
+      Time.add(Time.new!(end_at.hour, 0, 0), 3600, :second)
+    else
+      Time.new!(end_at.hour, 0, 0)
     end
   end
 


### PR DESCRIPTION
![Screenshot 2024-10-01 at 10 50 11](https://github.com/user-attachments/assets/db3d2e22-1c01-4aba-98bb-dcf60d6c3bc0)


- The times on the right side are now in full hours , we round down the start time , ie, if the start time is 05:48 , we will use 05:00 and round up the end time , if it is 20:30 , we use 21:00 .
- The timer also now shows in the format hh:mm