### PR TITLE
Removed the current time display , closes  #117

### DIFF
--- a/lib/omedis_web/components/time_tracking.ex
+++ b/lib/omedis_web/components/time_tracking.ex
@@ -33,9 +33,6 @@ defmodule OmedisWeb.TimeTracking do
   def dashboard_component(assigns) do
     ~H"""
     <div class="w-[100%] flex flex-col gap-1 ">
-      <div class="w-[100%] flex justify-end items-center gap-1">
-        <%= format_time(@current_time) %>
-      </div>
       <.dashboard_card
         categories={@categories}
         start_at={@start_at}


### PR DESCRIPTION
- I removed the current time that was displayed on the top right

![Screenshot 2024-10-01 at 11 13 48](https://github.com/user-attachments/assets/f77f0b3b-2907-4655-859a-bd29481f6c13)
