### PR TITLE
Remove unnecessary ID fields on index and show views

### DIFF
--- a/lib/omedis_web/live/log_category_live/show.ex
+++ b/lib/omedis_web/live/log_category_live/show.ex
@@ -11,7 +11,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
       <%= with_locale(@language, fn -> %>
         <%= gettext("Log category") %>
       <% end) %>
-      <%= @log_category.id %>
+
       <:subtitle>
         <%= with_locale(@language, fn -> %>
           <%= gettext("This is a log_category record from your database.") %>
@@ -50,9 +50,6 @@ defmodule OmedisWeb.LogCategoryLive.Show do
         <%= @log_category.name %>
       </:item>
 
-      <:item title={with_locale(@language, fn -> gettext("Group ID") end)}>
-        <%= @log_category.group_id %>
-      </:item>
       <:item title={with_locale(@language, fn -> gettext("Color code") end)}>
         <%= @log_category.color_code %>
       </:item>

--- a/lib/omedis_web/live/log_entry_live/index.ex
+++ b/lib/omedis_web/live/log_entry_live/index.ex
@@ -12,24 +12,8 @@ defmodule OmedisWeb.LogEntryLive.Index do
     </.header>
 
     <.table id="log_entries" rows={@streams.log_entries}>
-      <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("ID") end)}>
-        <%= log_entry.id %>
-      </:col>
-
       <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("Comment") end)}>
         <%= log_entry.comment %>
-      </:col>
-
-      <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("Tenant") end)}>
-        <%= log_entry.tenant_id %>
-      </:col>
-
-      <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("Log category") end)}>
-        <%= log_entry.log_category_id %>
-      </:col>
-
-      <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("User id") end)}>
-        <%= log_entry.user_id %>
       </:col>
 
       <:col :let={{_id, log_entry}} label={with_locale(@language, fn -> gettext("Start at") end)}>

--- a/lib/omedis_web/live/project_live/index.ex
+++ b/lib/omedis_web/live/project_live/index.ex
@@ -34,10 +34,6 @@ defmodule OmedisWeb.ProjectLive.Index do
         <%= project.name %>
       </:col>
 
-      <:col :let={{_id, project}} label={with_locale(@language, fn -> gettext("Tenant") end)}>
-        <%= project.tenant_id %>
-      </:col>
-
       <:col :let={{_id, project}} label={with_locale(@language, fn -> gettext("Position") end)}>
         <%= project.position %>
       </:col>

--- a/lib/omedis_web/live/project_live/show.ex
+++ b/lib/omedis_web/live/project_live/show.ex
@@ -33,10 +33,6 @@ defmodule OmedisWeb.ProjectLive.Show do
     <.list>
       <:item title={with_locale(@language, fn -> gettext("Name") end)}><%= @project.name %></:item>
 
-      <:item title={with_locale(@language, fn -> gettext("Tenant ID") end)}>
-        <%= @project.tenant_id %>
-      </:item>
-
       <:item title={with_locale(@language, fn -> gettext("Postion") end)}>
         <%= @project.position %>
       </:item>

--- a/lib/omedis_web/live/tenant_live/show.ex
+++ b/lib/omedis_web/live/tenant_live/show.ex
@@ -74,10 +74,6 @@ defmodule OmedisWeb.TenantLive.Show do
         <%= @tenant.description %>
       </:item>
 
-      <:item title={with_locale(@language, fn -> gettext("Owner") end)}>
-        <%= @tenant.owner_id %>
-      </:item>
-
       <:item title={with_locale(@language, fn -> gettext("Phone") end)}>
         <%= @tenant.phone %>
       </:item>


### PR DESCRIPTION
Resolves #149 and #147.

Before:
<img width="1495" alt="Screenshot 2024-10-07 at 12 54 42" src="https://github.com/user-attachments/assets/0a43bb61-c4b8-431e-b849-d2705a5a3865">
<img width="1495" alt="Screenshot 2024-10-07 at 13 59 49" src="https://github.com/user-attachments/assets/67147f5c-d550-44f7-94b6-dc3bc0c2d3d4">
![Screenshot 2024-10-07 at 14 09 09](https://github.com/user-attachments/assets/06308f7b-fa77-4cfa-8510-4bcdba86a59c)

After:
<img width="1495" alt="Screenshot 2024-10-07 at 13 54 22" src="https://github.com/user-attachments/assets/fc28d2f9-87f7-4eb0-8467-3c505ec1e4a5">
<img width="1501" alt="Screenshot 2024-10-07 at 14 40 32" src="https://github.com/user-attachments/assets/6bda2f69-c187-4ea1-bbd5-e918387a69fe">
<img width="1501" alt="Screenshot 2024-10-07 at 14 45 36" src="https://github.com/user-attachments/assets/263706eb-3dd9-4224-8f93-c9d45834395b">




