### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,25 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
+
+    env:
+      MIX_ENV: test
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: omedis_test
+
     strategy:
       matrix:
         otp: ["26.2.1"]
@@ -31,10 +45,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.mix
-            ~/.hex
-            deps
             _build
+            deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
@@ -45,61 +57,17 @@ jobs:
           mix local.rebar --force
           mix deps.get
 
-      - name: Compile the project with warnings as errors in source files
-        run: mix compile --warnings-as-errors lib/**/*.ex
+      - name: Compile
+        run: mix compile --warnings-as-errors
 
       - name: Check formatting
         run: mix format --check-formatted
 
-      - name: Restore database from cache
-        id: restore-db
-        uses: actions/cache@v3
-        with:
-          path: db_dump.sql
-          key: ${{ runner.os }}-db-${{ hashFiles('priv/repo/migrations/**/*', 'priv/repo/seeds.exs') }}
-          restore-keys: |
-            ${{ runner.os }}-db-
-
-      - name: Restore database from dump
-        if: steps.restore-db.outputs.cache-hit == 'true'
-        env:
-          PGHOST: localhost
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: omedis_test
-        run: |
-          pg_restore -U postgres -d omedis_test db_dump.sql
-
-      - name: Setup and dump database if no cache
-        if: steps.restore-db.outputs.cache-hit != 'true'
-        env:
-          PGHOST: localhost
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: omedis_test
-        run: |
-          mix ecto.create
-          mix ecto.migrate
-          mix run priv/repo/seeds.exs
-          pg_dump -Fc -f db_dump.sql -U postgres omedis_test
-
-      - name: Cache database dump
-        if: steps.restore-db.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: db_dump.sql
-          key: ${{ runner.os }}-db-${{ hashFiles('priv/repo/migrations/**/*', 'priv/repo/seeds.exs') }}
-
       - name: Run tests
         env:
-          MIX_ENV: test
-          PGHOST: localhost
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: omedis_test
-          CI: true # Set a CI environment variable
-          DISABLE_ML_FEATURES: true # Disable ML features
-        run: mix test
+          CI: true
+          DISABLE_ML_FEATURES: true
+        run: mix test --warnings-as-errors
 
       - name: Run Credo
         run: mix credo --strict


### PR DESCRIPTION
Optimize CI workflow by fixing caching and reducing unnecessary steps.

Here are the results.

<img width="903" alt="Screenshot 2024-10-25 at 18 15 17" src="https://github.com/user-attachments/assets/695630d2-57f2-4012-a4b3-ae97dde384a4">

The initial run takes ~3 minutes less than before because of the database changes. Subsequent runs take less than 1 minute. Note that after merging this PR the initial run will take ~6 minutes again, but after that, CI will be much faster.
Below are some details.

## Compilation

Before, we were compiling the app in two environments: `dev` and `test`, with each taking ~3 minutes. This fixes it by running all mix tasks (`compile --warnings-as-errors`, `credo`, `format`, `test`) in the `test` environment. That way, code compiled in one step can be reused in subsequent steps.

## Caching

The way GitHub Actions work, workflows running on branches can only access the cache created on the parent branch. That means that when dependencies get cached in a PR, another PR can't access that cache because it wasn't created in the parent branch (`main`). This ultimately means the cache was never reused.

This PR alleviates the issue by running CI in the `main` branch as well as PRs. Usually, there's no need for CI in the `main` because we've already run all the checks in the PR, but here it's useful for caching.

## Database

Creating and migrating a database is a quick thing to do, so there's no need for a dumping and restoring process which takes longer due to long cache writing in GitHub Actions. This wasn't always the case, but lately, I noticed in other projects that the cache gets written in a matter of minutes instead of seconds.