### PR TITLE
LogEntry bugfixes

### DIFF
--- a/lib/omedis_web/live/tenant_live/today.ex
+++ b/lib/omedis_web/live/tenant_live/today.ex
@@ -314,15 +314,22 @@ defmodule OmedisWeb.TenantLive.Today do
   @impl true
 
   def handle_event("select_log_category", %{"log_category_id" => log_category_id}, socket) do
-    create_or_stop_log_entry(
-      log_category_id,
-      socket.assigns.tenant.id,
-      socket.assigns.current_user.id
-    )
+    active_log_category_id =
+      case create_or_stop_log_entry(
+             log_category_id,
+             socket.assigns.tenant.id,
+             socket.assigns.current_user.id
+           ) do
+        {:ok, %LogEntry{end_at: nil}} ->
+          log_category_id
+
+        _ ->
+          nil
+      end
 
     {:noreply,
      socket
-     |> assign(:active_log_category_id, log_category_id)
+     |> assign(:active_log_category_id, active_log_category_id)
      |> assign(:categories, categories(socket.assigns.group.id, socket.assigns.project.id))}
   end
 


### PR DESCRIPTION
Resolves #245 & #258 

**Bugs fixed:**

- A bug that caused the default log entry to **always** be started/created on LiveView mount. This was marked as a bug, and not a feature, see comment [here](https://github.com/wintermeyer/omedis/issues/245#issuecomment-2446308677).
- A bug that caused the green dot, which is an indicator of an active log entry, to still appear on the UI, even if the active log entry has been stopped.

 

https://github.com/user-attachments/assets/1c75c200-e084-4f69-9a82-8ad235767282

