### PR TITLE
Derive `Phoenix.Param` for slugs

### DIFF
--- a/lib/omedis/accounts/group.ex
+++ b/lib/omedis/accounts/group.ex
@@ -13,6 +13,8 @@ defmodule Omedis.Accounts.Group do
   alias Omedis.Accounts.GroupUser
   alias Omedis.Accounts.User
 
+  @derive {Phoenix.Param, key: :slug}
+
   postgres do
     table "groups"
     repo Omedis.Repo

--- a/lib/omedis/accounts/tenant.ex
+++ b/lib/omedis/accounts/tenant.ex
@@ -19,6 +19,8 @@ defmodule Omedis.Accounts.Tenant do
   alias Omedis.Accounts.Group
   alias Omedis.Accounts.TenantsAccessFilter
 
+  @derive {Phoenix.Param, key: :slug}
+
   defimpl Ash.ToTenant, for: Omedis.Accounts.Tenant do
     def to_tenant(%{id: id}, _), do: "tenant_#{id}"
   end

--- a/lib/omedis_web/components/general_components.ex
+++ b/lib/omedis_web/components/general_components.ex
@@ -336,7 +336,7 @@ defmodule OmedisWeb.GeneralComponents do
               <ul role="list" class="-mx-2 mt-2 space-y-1">
                 <li>
                   <.link
-                    navigate={~p"/tenants/#{@current_tenant.slug}/groups"}
+                    navigate={~p"/tenants/#{@current_tenant}/groups"}
                     class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white"
                   >
                     <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400 group-hover:text-white">
@@ -349,7 +349,7 @@ defmodule OmedisWeb.GeneralComponents do
                 </li>
                 <li>
                   <.link
-                    navigate={~p"/tenants/#{@current_tenant.slug}/projects"}
+                    navigate={~p"/tenants/#{@current_tenant}/projects"}
                     class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white"
                   >
                     <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400 group-hover:text-white">
@@ -721,7 +721,7 @@ defmodule OmedisWeb.GeneralComponents do
               <ul role="list" class="-mx-2 mt-2 space-y-1">
                 <li>
                   <.link
-                    navigate={~p"/tenants/#{@current_tenant.slug}/groups"}
+                    navigate={~p"/tenants/#{@current_tenant}/groups"}
                     class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white"
                   >
                     <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400 group-hover:text-white">
@@ -734,7 +734,7 @@ defmodule OmedisWeb.GeneralComponents do
                 </li>
                 <li>
                   <.link
-                    navigate={~p"/tenants/#{@current_tenant.slug}/projects"}
+                    navigate={~p"/tenants/#{@current_tenant}/projects"}
                     class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white"
                   >
                     <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400 group-hover:text-white">
@@ -832,7 +832,7 @@ defmodule OmedisWeb.GeneralComponents do
   end
 
   defp get_current_tenant_path(nil), do: "/tenants"
-  defp get_current_tenant_path(current_tenant), do: "/tenants/#{current_tenant.slug}"
+  defp get_current_tenant_path(current_tenant), do: "/tenants/#{current_tenant}"
 
   defp tenants_link(assigns) do
     ~H"""

--- a/lib/omedis_web/live/group_live/index.ex
+++ b/lib/omedis_web/live/group_live/index.ex
@@ -22,14 +22,14 @@ defmodule OmedisWeb.GroupLive.Index do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}", true}
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}", true}
           ]}
           language={@language}
         />
 
         <div>
-          <.link navigate={~p"/tenants/#{@tenant.slug}"} class="button">
+          <.link navigate={~p"/tenants/#{@tenant}"} class="button">
             <%= gettext("Back") %>
           </.link>
         </div>
@@ -40,7 +40,7 @@ defmodule OmedisWeb.GroupLive.Index do
           <:actions>
             <.link
               :if={Ash.can?({Group, :create}, @current_user, actor: @current_user, tenant: @tenant)}
-              patch={~p"/tenants/#{@tenant.slug}/groups/new"}
+              patch={~p"/tenants/#{@tenant}/groups/new"}
             >
               <.button>
                 <%= with_locale(@language, fn -> %>
@@ -54,9 +54,7 @@ defmodule OmedisWeb.GroupLive.Index do
         <.table
           id="groups"
           rows={@streams.groups}
-          row_click={
-            fn {_id, group} -> JS.navigate(~p"/tenants/#{@tenant.slug}/groups/#{group.slug}") end
-          }
+          row_click={fn {_id, group} -> JS.navigate(~p"/tenants/#{@tenant}/groups/#{group}") end}
         >
           <:col :let={{_id, group}} label={with_locale(@language, fn -> gettext("Name") end)}>
             <%= group.name %>
@@ -71,7 +69,7 @@ defmodule OmedisWeb.GroupLive.Index do
               <.link
                 :if={Ash.can?({group, :update}, @current_user, actor: @current_user, tenant: @tenant)}
                 id={"edit-group-#{group.id}"}
-                patch={~p"/tenants/#{@tenant.slug}/groups/#{group.slug}/edit"}
+                patch={~p"/tenants/#{@tenant}/groups/#{group}/edit"}
                 class="font-semibold"
               >
                 <%= with_locale(@language, fn -> %>
@@ -98,7 +96,7 @@ defmodule OmedisWeb.GroupLive.Index do
           :if={@live_action in [:new, :edit]}
           id="group-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}/groups")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}/groups")}
         >
           <.live_component
             module={OmedisWeb.GroupLive.FormComponent}
@@ -109,13 +107,13 @@ defmodule OmedisWeb.GroupLive.Index do
             group={@group}
             current_user={@current_user}
             tenant={@tenant}
-            patch={~p"/tenants/#{@tenant.slug}/groups"}
+            patch={~p"/tenants/#{@tenant}/groups"}
           />
         </.modal>
         <PaginationComponent.pagination
           current_page={@current_page}
           language={@language}
-          resource_path={~p"/tenants/#{@tenant.slug}/groups"}
+          resource_path={~p"/tenants/#{@tenant}/groups"}
           total_pages={@total_pages}
         />
       </div>
@@ -163,7 +161,7 @@ defmodule OmedisWeb.GroupLive.Index do
           gettext("You are not authorized to access this page")
         end)
       )
-      |> redirect(to: ~p"/tenants/#{socket.assigns.tenant.slug}/groups")
+      |> redirect(to: ~p"/tenants/#{socket.assigns.tenant}/groups")
     end
   end
 
@@ -183,7 +181,7 @@ defmodule OmedisWeb.GroupLive.Index do
           gettext("You are not authorized to access this page")
         end)
       )
-      |> redirect(to: ~p"/tenants/#{socket.assigns.tenant.slug}/groups")
+      |> redirect(to: ~p"/tenants/#{socket.assigns.tenant}/groups")
     end
   end
 

--- a/lib/omedis_web/live/group_live/show.ex
+++ b/lib/omedis_web/live/group_live/show.ex
@@ -17,8 +17,8 @@ defmodule OmedisWeb.GroupLive.Show do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}/groups", false},
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}/groups", false},
             {@group.name, "", true}
           ]}
           language={@language}
@@ -27,7 +27,7 @@ defmodule OmedisWeb.GroupLive.Show do
         <.header>
           <:actions>
             <.link
-              patch={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories"}
+              patch={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories"}
               phx-click={JS.push_focus()}
             >
               <.button>
@@ -44,7 +44,7 @@ defmodule OmedisWeb.GroupLive.Show do
           <:item title={with_locale(@language, fn -> gettext("Slug") end)}><%= @group.slug %></:item>
         </.list>
 
-        <.back navigate={~p"/tenants/#{@tenant.slug}/groups"}>
+        <.back navigate={~p"/tenants/#{@tenant}/groups"}>
           <%= with_locale(@language, fn -> %>
             <%= gettext("Back to groups") %>
           <% end) %>
@@ -54,7 +54,7 @@ defmodule OmedisWeb.GroupLive.Show do
           :if={@live_action == :edit}
           id="group-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}/groups/#{@group}")}
         >
           <.live_component
             module={OmedisWeb.GroupLive.FormComponent}
@@ -64,7 +64,7 @@ defmodule OmedisWeb.GroupLive.Show do
             tenant={@tenant}
             language={@language}
             group={@group}
-            patch={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}"}
+            patch={~p"/tenants/#{@tenant}/groups/#{@group}"}
           />
         </.modal>
       </div>

--- a/lib/omedis_web/live/log_category_live/index.ex
+++ b/lib/omedis_web/live/log_category_live/index.ex
@@ -23,9 +23,9 @@ defmodule OmedisWeb.LogCategoryLive.Index do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}/groups", false},
-            {@group.name, ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}", false},
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}/groups", false},
+            {@group.name, ~p"/tenants/#{@tenant}/groups/#{@group}", false},
             {gettext("Log Categories"), "", true}
           ]}
           language={@language}
@@ -39,7 +39,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
           <:actions>
             <.link
               :if={Ash.can?({LogCategory, :create}, @current_user, tenant: @tenant)}
-              patch={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/new"}
+              patch={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/new"}
             >
               <.button>
                 <%= with_locale(@language, fn -> %>
@@ -55,9 +55,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
           rows={@streams.log_categories}
           row_click={
             fn {_id, log_category} ->
-              JS.navigate(
-                ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{log_category}"
-              )
+              JS.navigate(~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{log_category}")
             end
           }
         >
@@ -109,7 +107,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
           <:action :let={{_id, log_category}}>
             <div class="sr-only">
               <.link navigate={
-                ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{log_category}"
+                ~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{log_category}"
               }>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Show") %>
@@ -119,9 +117,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
 
             <.link
               :if={Ash.can?({log_category, :update}, @current_user, tenant: @tenant)}
-              patch={
-                ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{log_category}/edit"
-              }
+              patch={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{log_category}/edit"}
             >
               <%= with_locale(@language, fn -> %>
                 <%= gettext("Edit") %>
@@ -134,7 +130,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
           :if={@live_action in [:new, :edit]}
           id="log_category-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}/groups/#{@group}/log_categories")}
         >
           <.live_component
             module={OmedisWeb.LogCategoryLive.FormComponent}
@@ -149,13 +145,13 @@ defmodule OmedisWeb.LogCategoryLive.Index do
             language={@language}
             action={@live_action}
             log_category={@log_category}
-            patch={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories"}
+            patch={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories"}
           />
         </.modal>
         <PaginationComponent.pagination
           current_page={@current_page}
           language={@language}
-          resource_path={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories"}
+          resource_path={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories"}
           total_pages={@total_pages}
         />
       </div>
@@ -228,9 +224,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
     else
       socket
       |> put_flash(:error, gettext("You are not authorized to access this page"))
-      |> push_navigate(
-        to: ~p"/tenants/#{tenant.slug}/groups/#{socket.assigns.group.slug}/log_categories"
-      )
+      |> push_navigate(to: ~p"/tenants/#{tenant}/groups/#{socket.assigns.group}/log_categories")
     end
   end
 
@@ -248,9 +242,7 @@ defmodule OmedisWeb.LogCategoryLive.Index do
     else
       socket
       |> put_flash(:error, gettext("You are not authorized to access this page"))
-      |> push_navigate(
-        to: ~p"/tenants/#{tenant.slug}/groups/#{socket.assigns.group.slug}/log_categories"
-      )
+      |> push_navigate(to: ~p"/tenants/#{tenant}/groups/#{socket.assigns.group}/log_categories")
     end
   end
 

--- a/lib/omedis_web/live/log_category_live/show.ex
+++ b/lib/omedis_web/live/log_category_live/show.ex
@@ -19,11 +19,11 @@ defmodule OmedisWeb.LogCategoryLive.Show do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}/groups", false},
-            {@group.name, ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}", false},
-            {gettext("Log Categories"),
-             ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories", false},
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}/groups", false},
+            {@group.name, ~p"/tenants/#{@tenant}/groups/#{@group}", false},
+            {gettext("Log Categories"), ~p"/tenants/#{@tenant}/groups/#{@group}/log_categories",
+             false},
             {@log_category.name, "", true}
           ]}
           language={@language}
@@ -43,7 +43,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
           <:actions>
             <.link
               patch={
-                ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{@log_category}/show/edit"
+                ~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{@log_category}/show/edit"
               }
               phx-click={JS.push_focus()}
             >
@@ -55,7 +55,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
             </.link>
 
             <.link
-              navigate={~p"/tenants/#{@tenant.slug}/log_categories/#{@log_category}/log_entries"}
+              navigate={~p"/tenants/#{@tenant}/log_categories/#{@log_category}/log_entries"}
               phx-click={JS.push_focus()}
             >
               <.button>
@@ -80,7 +80,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
           </:item>
         </.list>
 
-        <.back navigate={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories"}>
+        <.back navigate={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories"}>
           <%= with_locale(@language, fn -> %>
             <%= gettext("Back to log categories") %>
           <% end) %>
@@ -91,9 +91,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
           id="log_category-modal"
           show
           on_cancel={
-            JS.patch(
-              ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{@log_category}"
-            )
+            JS.patch(~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{@log_category}")
           }
         >
           <.live_component
@@ -112,7 +110,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
             next_position={@next_position}
             language={@language}
             log_category={@log_category}
-            patch={~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{@log_category}"}
+            patch={~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{@log_category}"}
           />
         </.modal>
       </div>
@@ -174,7 +172,7 @@ defmodule OmedisWeb.LogCategoryLive.Show do
       |> put_flash(:error, gettext("You are not authorized to access this page"))
       |> push_navigate(
         to:
-          ~p"/tenants/#{tenant.slug}/groups/#{socket.assigns.group.slug}/log_categories/#{log_category.id}"
+          ~p"/tenants/#{tenant}/groups/#{socket.assigns.group}/log_categories/#{log_category.id}"
       )
     end
   end

--- a/lib/omedis_web/live/log_entry_live/index.ex
+++ b/lib/omedis_web/live/log_entry_live/index.ex
@@ -22,14 +22,13 @@ defmodule OmedisWeb.LogEntryLive.Index do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}/groups", false},
-            {@group.name, ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}", false},
-            {gettext("Log Categories"),
-             ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories", false},
-            {@log_category.name,
-             ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}/log_categories/#{@log_category.id}",
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}/groups", false},
+            {@group.name, ~p"/tenants/#{@tenant}/groups/#{@group}", false},
+            {gettext("Log Categories"), ~p"/tenants/#{@tenant}/groups/#{@group}/log_categories",
              false},
+            {@log_category.name,
+             ~p"/tenants/#{@tenant}/groups/#{@group}/log_categories/#{@log_category.id}", false},
             {"Log Entries", "", true}
           ]}
           language={@language}
@@ -60,7 +59,7 @@ defmodule OmedisWeb.LogEntryLive.Index do
         <PaginationComponent.pagination
           current_page={@current_page}
           language={@language}
-          resource_path={~p"/tenants/#{@tenant.slug}/log_categories/#{@log_category.id}/log_entries"}
+          resource_path={~p"/tenants/#{@tenant}/log_categories/#{@log_category.id}/log_entries"}
           total_pages={@total_pages}
         />
       </div>

--- a/lib/omedis_web/live/project_live/index.ex
+++ b/lib/omedis_web/live/project_live/index.ex
@@ -22,8 +22,8 @@ defmodule OmedisWeb.ProjectLive.Index do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Projects"), ~p"/tenants/#{@tenant.slug}", true}
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Projects"), ~p"/tenants/#{@tenant}", true}
           ]}
           language={@language}
         />
@@ -35,7 +35,7 @@ defmodule OmedisWeb.ProjectLive.Index do
           <:actions>
             <.link
               :if={Ash.can?({Project, :create}, @current_user, tenant: @tenant)}
-              patch={~p"/tenants/#{@tenant.slug}/projects/new"}
+              patch={~p"/tenants/#{@tenant}/projects/new"}
             >
               <.button>
                 <%= with_locale(@language, fn -> %>
@@ -50,7 +50,7 @@ defmodule OmedisWeb.ProjectLive.Index do
           id="projects"
           rows={@streams.projects}
           row_click={
-            fn {_id, project} -> JS.navigate(~p"/tenants/#{@tenant.slug}/projects/#{project}") end
+            fn {_id, project} -> JS.navigate(~p"/tenants/#{@tenant}/projects/#{project}") end
           }
         >
           <:col :let={{_id, project}} label={with_locale(@language, fn -> gettext("Name") end)}>
@@ -63,7 +63,7 @@ defmodule OmedisWeb.ProjectLive.Index do
 
           <:action :let={{_id, project}}>
             <div class="sr-only">
-              <.link navigate={~p"/tenants/#{@tenant.slug}/projects/#{project}"}>
+              <.link navigate={~p"/tenants/#{@tenant}/projects/#{project}"}>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Show") %>
                 <% end) %>
@@ -72,7 +72,7 @@ defmodule OmedisWeb.ProjectLive.Index do
 
             <.link
               :if={Ash.can?({project, :update}, @current_user, tenant: @tenant)}
-              patch={~p"/tenants/#{@tenant.slug}/projects/#{project}/edit"}
+              patch={~p"/tenants/#{@tenant}/projects/#{project}/edit"}
             >
               <%= with_locale(@language, fn -> %>
                 <%= gettext("Edit") %>
@@ -85,7 +85,7 @@ defmodule OmedisWeb.ProjectLive.Index do
           :if={@live_action in [:new, :edit]}
           id="project-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}/projects")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}/projects")}
         >
           <.live_component
             module={OmedisWeb.ProjectLive.FormComponent}
@@ -98,13 +98,13 @@ defmodule OmedisWeb.ProjectLive.Index do
             language={@language}
             action={@live_action}
             project={@project}
-            patch={~p"/tenants/#{@tenant.slug}/projects"}
+            patch={~p"/tenants/#{@tenant}/projects"}
           />
         </.modal>
         <PaginationComponent.pagination
           current_page={@current_page}
           language={@language}
-          resource_path={~p"/tenants/#{@tenant.slug}/projects"}
+          resource_path={~p"/tenants/#{@tenant}/projects"}
           total_pages={@total_pages}
         />
       </div>
@@ -217,7 +217,7 @@ defmodule OmedisWeb.ProjectLive.Index do
     socket
     |> assign(:page_title, with_locale(socket.assigns.language, fn -> gettext("Projects") end))
     |> assign(:user_has_access_rights, false)
-    |> push_patch(to: ~p"/tenants/#{tenant.slug}/projects")
+    |> push_patch(to: ~p"/tenants/#{tenant}/projects")
     |> put_flash(
       :error,
       with_locale(socket.assigns.language, fn ->

--- a/lib/omedis_web/live/project_live/show.ex
+++ b/lib/omedis_web/live/project_live/show.ex
@@ -17,8 +17,8 @@ defmodule OmedisWeb.ProjectLive.Show do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Projects"), ~p"/tenants/#{@tenant.slug}/projects", false},
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Projects"), ~p"/tenants/#{@tenant}/projects", false},
             {@project.name, "", true}
           ]}
           language={@language}
@@ -36,7 +36,7 @@ defmodule OmedisWeb.ProjectLive.Show do
 
           <:actions>
             <.link
-              patch={~p"/tenants/#{@tenant.slug}/projects/#{@project}/show/edit"}
+              patch={~p"/tenants/#{@tenant}/projects/#{@project}/show/edit"}
               phx-click={JS.push_focus()}
             >
               <.button :if={Ash.can?({@project, :update}, @current_user, tenant: @tenant)}>
@@ -58,7 +58,7 @@ defmodule OmedisWeb.ProjectLive.Show do
           </:item>
         </.list>
 
-        <.back navigate={~p"/tenants/#{@tenant.slug}/projects"}>
+        <.back navigate={~p"/tenants/#{@tenant}/projects"}>
           <%= with_locale(@language, fn -> gettext("Back to projects") end) %>
         </.back>
 
@@ -68,7 +68,7 @@ defmodule OmedisWeb.ProjectLive.Show do
           }
           id="project-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}/projects/#{@project}")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}/projects/#{@project}")}
         >
           <.live_component
             module={OmedisWeb.ProjectLive.FormComponent}
@@ -81,7 +81,7 @@ defmodule OmedisWeb.ProjectLive.Show do
             action={@live_action}
             language={@language}
             project={@project}
-            patch={~p"/tenants/#{@tenant.slug}/projects/#{@project}"}
+            patch={~p"/tenants/#{@tenant}/projects/#{@project}"}
           />
         </.modal>
       </div>
@@ -123,7 +123,7 @@ defmodule OmedisWeb.ProjectLive.Show do
       socket
     else
       socket
-      |> push_patch(to: ~p"/tenants/#{tenant.slug}/projects/#{socket.assigns.project.id}")
+      |> push_patch(to: ~p"/tenants/#{tenant}/projects/#{socket.assigns.project.id}")
       |> put_flash(
         :error,
         with_locale(socket.assigns.language, fn ->

--- a/lib/omedis_web/live/tenant_live/form_component.ex
+++ b/lib/omedis_web/live/tenant_live/form_component.ex
@@ -335,6 +335,6 @@ defmodule OmedisWeb.TenantLive.FormComponent do
     Enum.map(field.errors, &translate_error(&1))
   end
 
-  defp path_for(:edit, tenant), do: ~p"/tenants/#{tenant.slug}"
+  defp path_for(:edit, tenant), do: ~p"/tenants/#{tenant}"
   defp path_for(:new, _tenant), do: ~p"/tenants"
 end

--- a/lib/omedis_web/live/tenant_live/index.ex
+++ b/lib/omedis_web/live/tenant_live/index.ex
@@ -43,7 +43,7 @@ defmodule OmedisWeb.TenantLive.Index do
           <.table
             id="tenants"
             rows={@streams.tenants}
-            row_click={fn {_id, tenant} -> JS.navigate(~p"/tenants/#{tenant.slug}") end}
+            row_click={fn {_id, tenant} -> JS.navigate(~p"/tenants/#{tenant}") end}
           >
             <:col :let={{_id, tenant}} label={with_locale(@language, fn -> gettext("Name") end)}>
               <%= tenant.name %>
@@ -78,13 +78,13 @@ defmodule OmedisWeb.TenantLive.Index do
             </:col>
             <:action :let={{_id, tenant}}>
               <div class="sr-only">
-                <.link navigate={~p"/tenants/#{tenant.slug}"}>
+                <.link navigate={~p"/tenants/#{tenant}"}>
                   <%= with_locale(@language, fn -> %>
                     <%= gettext("Show") %>
                   <% end) %>
                 </.link>
               </div>
-              <.link patch={~p"/tenants/#{tenant.slug}/edit"}>
+              <.link patch={~p"/tenants/#{tenant}/edit"}>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Edit") %>
                 <% end) %>

--- a/lib/omedis_web/live/tenant_live/show.ex
+++ b/lib/omedis_web/live/tenant_live/show.ex
@@ -16,7 +16,7 @@ defmodule OmedisWeb.TenantLive.Show do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", true}
+            {@tenant.name, ~p"/tenants/#{@tenant}", true}
           ]}
           language={@language}
         />
@@ -27,7 +27,7 @@ defmodule OmedisWeb.TenantLive.Show do
           <:actions>
             <.link
               :if={Ash.can?({@tenant, :update}, @current_user)}
-              patch={~p"/tenants/#{@tenant.slug}/show/edit"}
+              patch={~p"/tenants/#{@tenant}/show/edit"}
               phx-click={JS.push_focus()}
             >
               <.button>
@@ -37,14 +37,14 @@ defmodule OmedisWeb.TenantLive.Show do
               </.button>
             </.link>
 
-            <.link patch={~p"/tenants/#{@tenant.slug}/projects"} phx-click={JS.push_focus()}>
+            <.link patch={~p"/tenants/#{@tenant}/projects"} phx-click={JS.push_focus()}>
               <.button>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Projects") %>
                 <% end) %>
               </.button>
             </.link>
-            <.link patch={~p"/tenants/#{@tenant.slug}/groups"} phx-click={JS.push_focus()}>
+            <.link patch={~p"/tenants/#{@tenant}/groups"} phx-click={JS.push_focus()}>
               <.button>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Groups") %>
@@ -52,7 +52,7 @@ defmodule OmedisWeb.TenantLive.Show do
               </.button>
             </.link>
 
-            <.link patch={~p"/tenants/#{@tenant.slug}/today"} phx-click={JS.push_focus()}>
+            <.link patch={~p"/tenants/#{@tenant}/today"} phx-click={JS.push_focus()}>
               <.button>
                 <%= with_locale(@language, fn -> %>
                   <%= gettext("Today") %>
@@ -173,7 +173,7 @@ defmodule OmedisWeb.TenantLive.Show do
           :if={@live_action == :edit}
           id="tenant-modal"
           show
-          on_cancel={JS.patch(~p"/tenants/#{@tenant.slug}")}
+          on_cancel={JS.patch(~p"/tenants/#{@tenant}")}
         >
           <.live_component
             module={OmedisWeb.TenantLive.FormComponent}
@@ -217,7 +217,7 @@ defmodule OmedisWeb.TenantLive.Show do
     else
       socket
       |> put_flash(:error, gettext("You are not authorized to access this page"))
-      |> push_navigate(to: ~p"/tenants/#{socket.assigns.tenant.slug}")
+      |> push_navigate(to: ~p"/tenants/#{socket.assigns.tenant}")
     end
   end
 

--- a/lib/omedis_web/live/tenant_live/today.ex
+++ b/lib/omedis_web/live/tenant_live/today.ex
@@ -20,9 +20,9 @@ defmodule OmedisWeb.TenantLive.Today do
           items={[
             {gettext("Home"), ~p"/", false},
             {gettext("Tenants"), ~p"/tenants", false},
-            {@tenant.name, ~p"/tenants/#{@tenant.slug}", false},
-            {gettext("Groups"), ~p"/tenants/#{@tenant.slug}/groups", false},
-            {@group.name, ~p"/tenants/#{@tenant.slug}/groups/#{@group.slug}", false},
+            {@tenant.name, ~p"/tenants/#{@tenant}", false},
+            {gettext("Groups"), ~p"/tenants/#{@tenant}/groups", false},
+            {@group.name, ~p"/tenants/#{@tenant}/groups/#{@group}", false},
             {gettext("Today"), "", true}
           ]}
           language={@language}
@@ -113,7 +113,7 @@ defmodule OmedisWeb.TenantLive.Today do
     {:noreply,
      socket
      |> push_navigate(
-       to: "/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}"
+       to: "/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}"
      )}
   end
 
@@ -347,7 +347,7 @@ defmodule OmedisWeb.TenantLive.Today do
      socket
      |> push_navigate(
        to:
-         "/tenants/#{socket.assigns.tenant.slug}/today?group_id=#{id}&project_id=#{socket.assigns.project.id}"
+         "/tenants/#{socket.assigns.tenant}/today?group_id=#{id}&project_id=#{socket.assigns.project.id}"
      )}
   end
 
@@ -356,7 +356,7 @@ defmodule OmedisWeb.TenantLive.Today do
      socket
      |> push_navigate(
        to:
-         "/tenants/#{socket.assigns.tenant.slug}/today?group_id=#{socket.assigns.group.id}&project_id=#{id}"
+         "/tenants/#{socket.assigns.tenant}/today?group_id=#{socket.assigns.group.id}&project_id=#{id}"
      )}
   end
 

--- a/test/omedis_web/live/group_live/index_test.exs
+++ b/test/omedis_web/live/group_live/index_test.exs
@@ -86,7 +86,7 @@ defmodule OmedisWeb.GroupLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups")
+        |> live(~p"/tenants/#{tenant}/groups")
 
       assert html =~ "Listing Groups"
       assert html =~ "New Group"
@@ -141,7 +141,7 @@ defmodule OmedisWeb.GroupLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups")
+        |> live(~p"/tenants/#{tenant}/groups")
 
       refute view |> element("#edit-group-#{group.id}") |> has_element?()
       refute view |> element("#delete-group-#{group.id}") |> has_element?()
@@ -171,7 +171,7 @@ defmodule OmedisWeb.GroupLive.IndexTest do
       {:ok, view, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups")
+        |> live(~p"/tenants/#{tenant}/groups")
 
       assert view
              |> element("#delete-group-#{group.id}")
@@ -210,7 +210,7 @@ defmodule OmedisWeb.GroupLive.IndexTest do
       {:ok, view, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups")
+        |> live(~p"/tenants/#{tenant}/groups")
 
       assert view
              |> element("#edit-group-#{group.id}")
@@ -224,7 +224,7 @@ defmodule OmedisWeb.GroupLive.IndexTest do
              |> form("#group-form", group: %{name: "New Group Name", slug: "new-group-name"})
              |> render_submit()
 
-      assert_patch(view, ~p"/tenants/#{tenant.slug}/groups")
+      assert_patch(view, ~p"/tenants/#{tenant}/groups")
 
       html = render(view)
       assert html =~ "Group updated successfully"
@@ -265,9 +265,9 @@ defmodule OmedisWeb.GroupLive.IndexTest do
       {:error, {:redirect, %{to: path, flash: flash}}} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/edit")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/edit")
 
-      assert path == ~p"/tenants/#{tenant.slug}/groups"
+      assert path == ~p"/tenants/#{tenant}/groups"
       assert flash["error"] == "You are not authorized to access this page"
     end
   end

--- a/test/omedis_web/live/group_live/show_test.exs
+++ b/test/omedis_web/live/group_live/show_test.exs
@@ -36,7 +36,7 @@ defmodule OmedisWeb.GroupLive.ShowTest do
       {:ok, _, html} =
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}")
 
       assert html =~ "Slug"
       assert html =~ group.name
@@ -73,7 +73,7 @@ defmodule OmedisWeb.GroupLive.ShowTest do
       {:ok, _, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}")
 
       assert html =~ group.name
     end
@@ -97,7 +97,7 @@ defmodule OmedisWeb.GroupLive.ShowTest do
       assert_raise Ash.Error.Query.NotFound, fn ->
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}")
       end
     end
   end

--- a/test/omedis_web/live/log_category_live/index_test.exs
+++ b/test/omedis_web/live/log_category_live/index_test.exs
@@ -104,7 +104,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       assert html =~ "Test Category"
     end
@@ -126,7 +126,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       assert html =~ "Test Category"
     end
@@ -148,7 +148,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       refute html =~ "Test Category"
       refute html =~ "New Log Category"
@@ -166,7 +166,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/new")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/new")
 
       assert html =~ "New Log Category"
 
@@ -181,7 +181,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
                )
                |> render_submit()
 
-      assert_patch(view, ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+      assert_patch(view, ~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       assert html =~ "Log category saved successfully"
       assert html =~ "New Category"
@@ -197,7 +197,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/new")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/new")
 
       assert html =~ "New Log Category"
 
@@ -212,7 +212,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
                )
                |> render_submit()
 
-      assert_patch(view, ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+      assert_patch(view, ~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       assert html =~ "Log category saved successfully"
       assert html =~ "New Category"
@@ -227,9 +227,9 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:error, {:live_redirect, %{flash: flash, to: to}}} =
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/new")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/new")
 
-      assert to == ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories"
+      assert to == ~p"/tenants/#{tenant}/groups/#{group}/log_categories"
       assert flash["error"] == "You are not authorized to access this page"
     end
 
@@ -242,7 +242,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, _html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/new")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/new")
 
       html =
         view
@@ -279,7 +279,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       # Verify position controls are rendered
       assert html =~ "move-up-#{second.id}"
@@ -315,7 +315,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, html} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       refute html =~ "move-up-#{log_category.id}"
       refute html =~ "move-down-#{log_category.id}"
@@ -347,7 +347,7 @@ defmodule OmedisWeb.LogCategoryLive.IndexTest do
       {:ok, view, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories")
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories")
 
       # Test moving up
       view

--- a/test/omedis_web/live/log_category_live/show_test.exs
+++ b/test/omedis_web/live/log_category_live/show_test.exs
@@ -103,9 +103,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
       {:ok, _show_live, html} =
         conn
         |> log_in_user(owner)
-        |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
-        )
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}")
 
       assert html =~ log_category.name
       assert html =~ "Edit log_category"
@@ -121,9 +119,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
       {:ok, _show_live, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
-        )
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}")
 
       assert html =~ log_category.name
       assert html =~ "Edit log_category"
@@ -139,9 +135,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
       assert_raise Ash.Error.Query.NotFound, fn ->
         conn
         |> log_in_user(user)
-        |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
-        )
+        |> live(~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}")
       end
     end
   end
@@ -158,7 +152,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
         conn
         |> log_in_user(owner)
         |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}/show/edit"
+          ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}/show/edit"
         )
 
       assert html =~ "Edit log_category"
@@ -175,7 +169,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
 
       assert_patch(
         show_live,
-        ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
+        ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}"
       )
 
       assert html =~ "Log category saved successfully"
@@ -193,7 +187,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
         conn
         |> log_in_user(authorized_user)
         |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}/show/edit"
+          ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}/show/edit"
         )
 
       assert html =~ "Edit log_category"
@@ -205,7 +199,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
 
       assert_patch(
         show_live,
-        ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
+        ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}"
       )
 
       assert html =~ "Log category saved successfully"
@@ -234,11 +228,11 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
         conn
         |> log_in_user(user)
         |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}/show/edit"
+          ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}/show/edit"
         )
 
       assert to ==
-               ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}"
+               ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}"
 
       assert flash["error"] == "You are not authorized to access this page"
     end
@@ -254,7 +248,7 @@ defmodule OmedisWeb.LogCategoryLive.ShowTest do
         conn
         |> log_in_user(authorized_user)
         |> live(
-          ~p"/tenants/#{tenant.slug}/groups/#{group.slug}/log_categories/#{log_category.id}/show/edit"
+          ~p"/tenants/#{tenant}/groups/#{group}/log_categories/#{log_category.id}/show/edit"
         )
 
       assert html =

--- a/test/omedis_web/live/log_entry_live/index_test.exs
+++ b/test/omedis_web/live/log_entry_live/index_test.exs
@@ -84,7 +84,7 @@ defmodule OmedisWeb.LogEntryLive.IndexTest do
       {:ok, _lv, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/log_categories/#{log_category.id}/log_entries")
+        |> live(~p"/tenants/#{tenant}/log_categories/#{log_category.id}/log_entries")
 
       assert html =~ "User&#39;s log entry"
       assert html =~ "Owner&#39;s log entry"
@@ -116,7 +116,7 @@ defmodule OmedisWeb.LogEntryLive.IndexTest do
       {:ok, _lv, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/log_categories/#{log_category.id}/log_entries")
+        |> live(~p"/tenants/#{tenant}/log_categories/#{log_category.id}/log_entries")
 
       assert html =~ "Test comment 1"
       assert html =~ "Test comment 2"
@@ -157,7 +157,7 @@ defmodule OmedisWeb.LogEntryLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/log_categories/#{log_category.id}/log_entries")
+        |> live(~p"/tenants/#{tenant}/log_categories/#{log_category.id}/log_entries")
 
       refute html =~ "Test comment"
     end

--- a/test/omedis_web/live/project_live/index_test.exs
+++ b/test/omedis_web/live/project_live/index_test.exs
@@ -57,7 +57,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/projects")
+        |> live(~p"/tenants/#{tenant}/projects")
 
       assert html =~ "Test Project"
     end
@@ -73,7 +73,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects")
+        |> live(~p"/tenants/#{tenant}/projects")
 
       assert html =~ project.name
     end
@@ -89,7 +89,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects")
+        |> live(~p"/tenants/#{tenant}/projects")
 
       refute html =~ project.name
     end
@@ -105,7 +105,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, _, html} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects")
+        |> live(~p"/tenants/#{tenant}/projects")
 
       refute html =~ "New Project"
     end
@@ -121,7 +121,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, index_live, _} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects")
+        |> live(~p"/tenants/#{tenant}/projects")
 
       refute has_element?(index_live, "#edit-project-#{project.id}")
     end
@@ -136,7 +136,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, index_live, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/projects/new")
+        |> live(~p"/tenants/#{tenant}/projects/new")
 
       assert html =~ "New Project"
 
@@ -147,7 +147,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects")
 
       assert html =~ "Project saved."
       assert html =~ "Dummy Project"
@@ -161,7 +161,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, index_live, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/new")
+        |> live(~p"/tenants/#{tenant}/projects/new")
 
       assert html =~ "New Project"
 
@@ -172,7 +172,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects")
 
       assert html =~ "Project saved."
       assert html =~ "Dummy Project"
@@ -186,9 +186,9 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:error, {:live_redirect, %{to: redirect_path, flash: flash}}} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/new")
+        |> live(~p"/tenants/#{tenant}/projects/new")
 
-      assert redirect_path == ~p"/tenants/#{tenant.slug}/projects"
+      assert redirect_path == ~p"/tenants/#{tenant}/projects"
       assert flash["error"] == "You are not authorized to access this page"
     end
   end
@@ -205,7 +205,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, index_live, _} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/edit")
 
       params = %{name: "Updated Project"}
 
@@ -214,7 +214,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects")
 
       assert html =~ "Project saved."
       assert html =~ "Updated Project"
@@ -231,7 +231,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:ok, index_live, _} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/edit")
 
       params = %{name: "Updated Project"}
 
@@ -240,7 +240,7 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects")
 
       assert html =~ "Project saved."
       assert html =~ "Updated Project"
@@ -257,9 +257,9 @@ defmodule OmedisWeb.ProjectLive.IndexTest do
       {:error, {:live_redirect, %{to: redirect_path, flash: flash}}} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/edit")
 
-      assert redirect_path == ~p"/tenants/#{tenant.slug}/projects"
+      assert redirect_path == ~p"/tenants/#{tenant}/projects"
       assert flash["error"] == "You are not authorized to access this page"
     end
   end

--- a/test/omedis_web/live/project_live/show_test.exs
+++ b/test/omedis_web/live/project_live/show_test.exs
@@ -56,7 +56,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       {:ok, _, html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}")
 
       assert html =~ "Project"
       assert html =~ project.name
@@ -84,7 +84,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       {:ok, _, html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}")
 
       assert html =~ "Project"
       assert html =~ "Edit project"
@@ -102,7 +102,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       assert_raise Ash.Error.Query.NotFound, fn ->
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}")
       end
     end
   end
@@ -129,7 +129,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       {:ok, index_live, _} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/show/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/show/edit")
 
       params = Map.put(params, :name, "Updated Project")
 
@@ -138,7 +138,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects/#{project.id}")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects/#{project.id}")
 
       assert html =~ "Project saved."
       assert html =~ "Updated Project"
@@ -165,7 +165,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       {:ok, index_live, _} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/show/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/show/edit")
 
       params = Map.put(params, :name, "Updated Project")
 
@@ -174,7 +174,7 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
                |> form("#project-form", project: params)
                |> render_submit()
 
-      assert_patch(index_live, ~p"/tenants/#{tenant.slug}/projects/#{project.id}")
+      assert_patch(index_live, ~p"/tenants/#{tenant}/projects/#{project.id}")
 
       assert html =~ "Project saved."
       assert html =~ "Updated Project"
@@ -204,9 +204,9 @@ defmodule OmedisWeb.ProjectLive.ShowTest do
       {:error, {:live_redirect, %{to: redirect_path, flash: flash}}} =
         conn
         |> log_in_user(user)
-        |> live(~p"/tenants/#{tenant.slug}/projects/#{project.id}/show/edit")
+        |> live(~p"/tenants/#{tenant}/projects/#{project.id}/show/edit")
 
-      assert redirect_path == ~p"/tenants/#{tenant.slug}/projects/#{project.id}"
+      assert redirect_path == ~p"/tenants/#{tenant}/projects/#{project.id}"
       assert flash["error"] == "You are not authorized to access this page"
     end
   end

--- a/test/omedis_web/live/tenant_live/index_test.exs
+++ b/test/omedis_web/live/tenant_live/index_test.exs
@@ -231,7 +231,7 @@ defmodule OmedisWeb.TenantLive.IndexTest do
         })
 
       assert {:error, {:live_redirect, %{to: path, flash: flash}}} =
-               live(conn, ~p"/tenants/#{tenant.slug}/edit")
+               live(conn, ~p"/tenants/#{tenant}/edit")
 
       assert path == ~p"/tenants"
       assert flash["error"] == "You are not authorized to access this page"
@@ -240,7 +240,7 @@ defmodule OmedisWeb.TenantLive.IndexTest do
     test "edits the tenant when user has access", %{conn: conn, user: user} do
       {:ok, tenant} = create_tenant(%{owner_id: user.id})
 
-      {:ok, show_live, _html} = live(conn, ~p"/tenants/#{tenant.slug}/edit")
+      {:ok, show_live, _html} = live(conn, ~p"/tenants/#{tenant}/edit")
 
       assert show_live
              |> form("#tenant-form", tenant: %{street: ""})

--- a/test/omedis_web/live/tenant_live/show_test.exs
+++ b/test/omedis_web/live/tenant_live/show_test.exs
@@ -29,7 +29,7 @@ defmodule OmedisWeb.TenantLive.ShowTest do
           resource_name: "Tenant"
         })
 
-      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant.slug}")
+      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant}")
 
       assert html =~ tenant.name
     end
@@ -38,7 +38,7 @@ defmodule OmedisWeb.TenantLive.ShowTest do
       {:ok, tenant} = create_tenant()
 
       assert_raise Ash.Error.Query.NotFound, fn ->
-        live(conn, ~p"/tenants/#{tenant.slug}")
+        live(conn, ~p"/tenants/#{tenant}")
       end
     end
 
@@ -46,7 +46,7 @@ defmodule OmedisWeb.TenantLive.ShowTest do
       {:ok, owned_tenant} =
         create_tenant(%{name: "Owned Tenant", slug: "owned-tenant", owner_id: user.id})
 
-      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{owned_tenant.slug}")
+      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{owned_tenant}")
 
       assert html =~ owned_tenant.name
     end
@@ -66,17 +66,17 @@ defmodule OmedisWeb.TenantLive.ShowTest do
           write: false
         })
 
-      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant.slug}")
+      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant}")
       refute html =~ "Edit tenant"
 
       Ash.update!(access_right, %{write: true, update: false})
 
-      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant.slug}")
+      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant}")
       assert html =~ "Edit tenant"
 
       Ash.update!(access_right, %{write: false, update: true})
 
-      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant.slug}")
+      {:ok, _show_live, html} = live(conn, ~p"/tenants/#{tenant}")
       assert html =~ "Edit tenant"
     end
 
@@ -84,14 +84,14 @@ defmodule OmedisWeb.TenantLive.ShowTest do
       {:ok, owned_tenant} =
         create_tenant(%{name: "Owned Tenant", slug: "owned-tenant", owner_id: user.id})
 
-      {:ok, show_live, html} = live(conn, ~p"/tenants/#{owned_tenant.slug}")
+      {:ok, show_live, html} = live(conn, ~p"/tenants/#{owned_tenant}")
 
       assert html =~ "Edit tenant"
 
       assert show_live |> element("a", "Edit tenant") |> render_click() =~
                "Edit Tenant"
 
-      assert_patch(show_live, ~p"/tenants/#{owned_tenant.slug}/show/edit")
+      assert_patch(show_live, ~p"/tenants/#{owned_tenant}/show/edit")
 
       assert show_live
              |> form("#tenant-form", tenant: %{street: ""})

--- a/test/omedis_web/live/tenant_live/today_test.exs
+++ b/test/omedis_web/live/tenant_live/today_test.exs
@@ -85,7 +85,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       assert lv
              |> element("#log-category-#{log_category.id}")
@@ -123,7 +123,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       # Create a log entry
       assert lv
@@ -172,7 +172,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(owner)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       # Start log entry for the first category
       assert lv
@@ -226,7 +226,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       assert lv
              |> element("#log-category-#{log_category.id}")
@@ -264,7 +264,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       # Create a log entry
       assert lv
@@ -313,7 +313,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(authorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       # Start log entry for the first category
       assert lv
@@ -393,7 +393,7 @@ defmodule OmedisWeb.TenantLive.TodayTest do
       {:ok, lv, _html} =
         conn
         |> log_in_user(unauthorized_user)
-        |> live(~p"/tenants/#{tenant.slug}/today?group_id=#{group.id}&project_id=#{project.id}")
+        |> live(~p"/tenants/#{tenant}/today?group_id=#{group.id}&project_id=#{project.id}")
 
       refute lv
              |> element("#log-category-#{log_category.id}")


### PR DESCRIPTION
Resolves #268.
![Screenshot 2024-11-06 at 08 42 39](https://github.com/user-attachments/assets/1b65cb61-245c-4ffb-a448-757c43fba585)

The two search results from the screenshot above are unchanged because `attrs` is a map, and `Phoenix.Param` protocol is [not](https://hexdocs.pm/phoenix/1.7.14/Phoenix.Param.html#:~:text=Phoenix%20implements%20this%20protocol%20for%20integers%2C%20binaries%2C%20atoms%2C%20and%20structs) implemented for maps.
